### PR TITLE
Syntax highlight

### DIFF
--- a/IoT.cpp
+++ b/IoT.cpp
@@ -3,56 +3,59 @@
 #include "IoT.h"
 
 
-void    defineRele(int pin){
-   pinMode(pin, OUTPUT);
+void defineRele(int pin){
+  pinMode(pin, OUTPUT);
 }
-void    ligaRele(int pin){
-   digitalWrite(pin, HIGH);
+
+void ligaRele(int pin){
+  digitalWrite(pin, HIGH);
 }
-void    desligaRele(int pin){
-   digitalWrite(pin,LOW);
+
+void desligaRele(int pin){
+  digitalWrite(pin,LOW);
 }
+
 void defineLed(int led){
-    pinMode(led, OUTPUT);
+  pinMode(led, OUTPUT);
 }
 
 void acendeLed(int pin){
-	digitalWrite(pin, HIGH);
+  digitalWrite(pin, HIGH);
 }
 
 void apagaLed(int pin){
-	digitalWrite(pin, LOW);
+  digitalWrite(pin, LOW);
 }
 
 void brilhaLed(int pin, int brilho){
-	analogWrite(pin, brilho);
+  analogWrite(pin, brilho);
 }
 
 void espera(long time){
-	delay(time);
+  delay(time);
 }
 
 void botao(int pin){
-	pinMode(pin, INPUT_PULLUP);
+  pinMode(pin, INPUT_PULLUP);
 }
 
 uint8_t verificaBotao(int pin){
-	return digitalRead(pin);
+  return digitalRead(pin);
 }
 
 int botaoLigado(int pin){
-	return (digitalRead(pin) == LOW);
+  return (digitalRead(pin) == LOW);
 }
 
 int botaoDesligado(int pin){
-	return (digitalRead(pin) == HIGH);
+  return (digitalRead(pin) == HIGH);
 }
+
+
 uint8_t Motor::conectar(int pin){
-    Servo::attach(pin);
+  Servo::attach(pin);
 }
+
 void Motor::girar(int graus){
-    Servo::write(graus);
+  Servo::write(graus);
 }
-
-
-

--- a/IoT.h
+++ b/IoT.h
@@ -1,39 +1,37 @@
-
-
-
 #ifndef IoT_h
 #define IoT_h
 
-	#include "Arduino.h"
-	#include "Servo.h"
-	#define ENTRADA   INPUT
-	#define SAIDA     OUTPUT
-    #define LIGADO    0
-    #define DESLIGADO 1
-    #define se        if 
-    #define senao     else
-    #define repita(x) for (int _Iot_counter=0; _Iot_counter < x ; _Iot_counter++)
-    #define Numero    int
-    
+#include "Arduino.h"
+#include "Servo.h"
 
-	void    acendeLed(int pin);
-	void    apagaLed(int pin);
-	void    espera(long mili);
+#define ENTRADA   INPUT
+#define SAIDA     OUTPUT
+#define LIGADO    0
+#define DESLIGADO 1
+#define se        if
+#define senao     else
+#define repita(x) for (int _Iot_counter=0; _Iot_counter < x ; _Iot_counter++)
+#define Numero    int
 
-        void    defineRele(int pin);
-        void    ligaRele(int pin);
-        void    desligaRele(int pin);
-	void    defineLed(int pin);
-	void    brilhaLed(int pin, int brilho);
-	void    botao(int pin);
-	uint8_t verificaBotao(int pin);
-	int     botaoLigado(int pin);
-	int     botaoDesligado(int pin);
 
-    class Motor : Servo{
-       public:
-	      uint8_t conectar(int pin);
-	      void girar(int angulo);
-    };
-    
+void    acendeLed(int pin);
+void    apagaLed(int pin);
+void    espera(long mili);
+
+void    defineRele(int pin);
+void    ligaRele(int pin);
+void    desligaRele(int pin);
+void    defineLed(int pin);
+void    brilhaLed(int pin, int brilho);
+void    botao(int pin);
+uint8_t verificaBotao(int pin);
+int     botaoLigado(int pin);
+int     botaoDesligado(int pin);
+
+class Motor : Servo{
+public:
+  uint8_t conectar(int pin);
+  void girar(int angulo);
+};
+
 #endif

--- a/keywords.txt
+++ b/keywords.txt
@@ -1,0 +1,47 @@
+#######################################
+# Syntax Coloring Map
+#######################################
+
+#######################################
+# Datatypes (KEYWORD1)
+#######################################
+
+Motor	KEYWORD1
+
+#######################################
+# Methods and Functions (KEYWORD2)
+#######################################
+acendeLed	KEYWORD2
+apagaLed	KEYWORD2
+defineLed	KEYWORD2
+brilhaLed	KEYWORD2
+
+espera	KEYWORD2
+repita	KEYWORD2
+
+defineRele	KEYWORD2
+ligaRele	KEYWORD2
+desligaRele	KEYWORD2
+
+botao	KEYWORD2
+verificaBotao	KEYWORD2
+botaoLigado	KEYWORD2
+botaoDesligado	KEYWORD2
+
+conectar	KEYWORD2
+girar	KEYWORD2
+
+
+#######################################
+# Constants (LITERAL1)
+#######################################
+ENTRADA	LITERAL1
+SAIDA	LITERAL1
+
+LIGADO	LITERAL1
+DESLIGADO	LITERAL1
+
+Numero	LITERAL1
+se	LITERAL2
+senao	LITERAL2
+


### PR DESCRIPTION
- Adicionado `keywords.txt` para ativar o syntax highlight;
- Código refatorado para arrumara a idenação (Tabs e Espaços estavam misturados).

Infelizmente a IDE do Arduino só aceita 3 cores para as keywords das bibliotecas, então comandos como `se`, `senao`, etc acabam ficando da mesma cor que as funções (`ligaLed`, `defineRele`, etc).
